### PR TITLE
Filter night routes

### DIFF
--- a/scripts/populate_db/settings.json
+++ b/scripts/populate_db/settings.json
@@ -39,6 +39,13 @@
             "trip_id"
         ]
     },
+    "remove_cols_containing": {
+        "pontos_routes": {
+            "route_short_name": [
+                "SN"
+            ]
+        }
+    },
     "flag_params": [
         "empty_tables"
     ]


### PR DESCRIPTION
Mais detalhes no Kanban: https://github.com/orgs/prefeitura-rio/projects/18/views/1
Nome do card: **[BE] Remover rotas noturnas em routes**

---
### Objetivo
* Tirar tudo que tiver `SN` em `route_short_name`

### O que foi alterado?

* Uma configuração para filtrar rotas noturnas em `settings.json`
* Refatoramento da função `validate_col_values()` que fará essa filtragem, para ser compatível com outras funcionalidades pendentes em `dev-local`
* Código para filtrar rotas noturnas na função `validate_col_values()`

### Como usar

Em `scripts\populate_db\settings.json`, é possível ignorar qualquer coluna se o valor conter o subtexto.

No exemplo abaixo, o subtexto será `teste`:
```json
{
    "remove_cols_containing": {
        "tabela1": {
            "coluna1": [
                "teste"
            ]
        }
    },
}
```

Antes:
```diff
    tabela1
    ---
    coluna1     coluna2
-   teste1      a       
-   teste2      b       
    maçã        c
    banana      d
```

Depois:

```log
tabela1
---
coluna1     coluna2
maçã        c
banana      d
```