### PR TITLE
Feat/trip id frequencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,8 @@ O que NÃO pode alterar ali sem quebrar o Kubernetes:
 Os diagramas dos endpoints (e ) [here](https://miro.com/app/board/o9J_lqIY7Eg=/).
 > Os diagramas estão em português.
 
+A página inicial mostra todos os endpoints disponíveis.
+
 ### Pontos (gtfs)
 
 Todos os endpoints estão no endereço `/gtfs`.

--- a/README.md
+++ b/README.md
@@ -251,6 +251,86 @@ A página inicial mostra todos os endpoints disponíveis.
 
 Todos os endpoints estão no endereço `/gtfs`.
 
+#### agency
+
+Endereço: `/gtfs/agency`
+
+Parâmetros:
+
+* `route_type` - Filtra por 1 ou mais route_type
+  * Uso: `route_type=1,2,3`
+  * Exemplo real: <http://localhost:8010/gtfs/agency/?route_type=2,3>
+
+#### calendar
+
+Endereço: `/gtfs/calendar`
+
+Parâmetros:
+
+* `route_type` - Filtra por 1 ou mais route_type
+  * Uso: `route_type=1,2,3`
+  * Exemplo real: <http://localhost:8010/gtfs/calendar/?route_type=2,3>
+
+#### calendar_dates
+
+Endereço: `/gtfs/calendar_dates`
+
+Parâmetros:
+
+* `route_type` - Filtra por 1 ou mais route_type
+  * Uso: `route_type=1,2,3`
+  * Exemplo real: <http://localhost:8010/gtfs/calendar_dates/?route_type=2,3>
+
+#### frequencies
+
+Endereço: `/gtfs/frequencies`
+
+Parâmetros:
+
+* `route_type` - Filtra por 1 ou mais route_type
+  * Uso: `route_type=1,2,3`
+  * Exemplo real: <http://localhost:8010/gtfs/frequencies/?route_type=2,3>
+
+#### routes
+
+Endereço: `/gtfs/routes`
+
+Parâmetros:
+
+* `route_type` - Filtra por 1 ou mais route_type
+  * Uso: `route_type=1,2,3`
+  * Exemplo real: <http://localhost:8010/gtfs/routes/?route_type=2,3>
+
+#### trips
+
+Endereço: `/gtfs/trips`
+
+Parâmetros:
+
+* `route_type` - Filtra por 1 ou mais route_type
+  * Uso: `route_type=1,2,3`
+  * Exemplo real: <http://localhost:8010/gtfs/trips/?route_type=2,3>
+
+#### shapes
+
+Endereço: `/gtfs/shapes`
+
+Parâmetros:
+
+* `route_type` - Filtra por 1 ou mais route_type
+  * Uso: `route_type=1,2,3`
+  * Exemplo real: <http://localhost:8010/gtfs/shapes/?route_type=2,3>
+
+#### stops
+
+Endereço: `/gtfs/stops`
+
+Parâmetros:
+
+* `route_type` - Filtra por 1 ou mais route_type
+  * Uso: `route_type=1,2,3`
+  * Exemplo real: <http://localhost:8010/gtfs/stops/?route_type=2,3>
+
 #### stop_times
 
 Endereço: `/gtfs/stop_times`
@@ -283,6 +363,10 @@ Parâmetros:
 * É possível combinar todos os parâmetros acima.
   * Exemplo: `trip_id=a,b&stop_id=1,2,3&stop_id__all=2,3,4`
   * Exemplo real: <http://localhost:8010/gtfs/stop_times/?trip_id=O0041CAA0AIDU01,O0309AAA0AVDU01&stop_id=2028O00023C0,5144O00512C9>
+
+* `route_type` - Filtra por 1 ou mais route_type
+  * Uso: `route_type=1,2,3`
+  * Exemplo real: <http://localhost:8010/gtfs/stop_times/?route_type=2,3>
 
 ## Apps
 

--- a/README.md
+++ b/README.md
@@ -368,6 +368,18 @@ Parâmetros:
   * Uso: `route_type=1,2,3`
   * Exemplo real: <http://localhost:8010/gtfs/stop_times/?route_type=2,3>
 
+### predictor
+
+#### shapes_with_stops
+
+Endereço: `/predictor/shapes_with_stops`
+
+Parâmetros:
+
+* `route_type` - Filtra por 1 ou mais route_type
+  * Uso: `route_type=1,2,3`
+  * Exemplo real: <http://localhost:8010/predictor/shapes_with_stops/?route_type=2,3>
+
 ## Apps
 
 ### Utils

--- a/README.md
+++ b/README.md
@@ -287,6 +287,10 @@ Endereço: `/gtfs/frequencies`
 
 Parâmetros:
 
+* `trip_id` - Filtra por 1 ou mais trip_id
+  * Uso: `trip_id=1,2,3`
+  * Exemplo real: <http://localhost:8010/gtfs/frequencies/?trip_id=O0006AAA0AVDU01,O0007AAA0AVDU01>
+
 * `route_type` - Filtra por 1 ou mais route_type
   * Uso: `route_type=1,2,3`
   * Exemplo real: <http://localhost:8010/gtfs/frequencies/?route_type=2,3>

--- a/mobilidade_rio/mobilidade_rio/pontos/views.py
+++ b/mobilidade_rio/mobilidade_rio/pontos/views.py
@@ -23,6 +23,18 @@ class AgencyViewSet(viewsets.ModelViewSet):
     permission_classes = (permissions.IsAuthenticatedOrReadOnly,)
     queryset = Agency.objects.all().order_by("agency_id")
 
+    def get_queryset(self):
+        queryset = Agency.objects.all().order_by("agency_id")
+
+        # filter by route_type
+        route_type = self.request.query_params.get("route_type")
+        if route_type is not None:
+            route_type = route_type.split(",")
+            routes = Routes.objects.filter(route_type__in=route_type)
+            queryset = queryset.filter(agency_id__in=routes.values_list("agency_id", flat=True)).order_by("agency_id")
+
+        return queryset
+
 
 class CalendarViewSet(viewsets.ModelViewSet):
 

--- a/mobilidade_rio/mobilidade_rio/pontos/views.py
+++ b/mobilidade_rio/mobilidade_rio/pontos/views.py
@@ -139,6 +139,14 @@ class ShapesViewSet(viewsets.ModelViewSet):
             shape_id = shape_id.split(",")
             queryset = queryset.filter(shape_id__in=shape_id).order_by("shape_id")
 
+        # filter by route_type
+        route_type = self.request.query_params.get("route_type")
+        if route_type is not None:
+            route_type = route_type.split(",")
+            routes = Routes.objects.filter(route_type__in=route_type)
+            trips = Trips.objects.filter(route_id__in=routes.values_list('route_id'))
+            queryset = queryset.filter(shape_id__in=trips.values_list('shape_id'))
+
         return queryset
 
 

--- a/mobilidade_rio/mobilidade_rio/pontos/views.py
+++ b/mobilidade_rio/mobilidade_rio/pontos/views.py
@@ -165,6 +165,12 @@ class StopsViewSet(viewsets.ModelViewSet):
         if stop_code is not None:
             queryset = queryset.filter(stop_id=stop_code).order_by("stop_id")
 
+        # fillter by stop_id
+        stop_id = self.request.query_params.get("stop_id")
+        if stop_id is not None:
+            queryset = queryset.filter(stop_id=stop_id).order_by("stop_id")
+
+        # fillter by stop_code
         stop_code = self.request.query_params.get("stop_code")
         if stop_code is not None:
             # split comma

--- a/mobilidade_rio/mobilidade_rio/pontos/views.py
+++ b/mobilidade_rio/mobilidade_rio/pontos/views.py
@@ -174,6 +174,15 @@ class StopsViewSet(viewsets.ModelViewSet):
             stop_code = stop_code.split(",")
             queryset = queryset.filter(stop_code__in=stop_code).order_by("stop_id")
 
+        # filter by route_type
+        route_type = self.request.query_params.get("route_type")
+        if route_type is not None:
+            route_type = route_type.split(",")
+            routes = Routes.objects.filter(route_type__in=route_type)
+            trips = Trips.objects.filter(route_id__in=routes.values_list('route_id'))
+            stoptimes = StopTimes.objects.filter(trip_id__in=trips.values_list('trip_id'))
+            queryset = queryset.filter(stop_id__in=stoptimes.values_list('stop_id'))
+
         return queryset
 
 

--- a/mobilidade_rio/mobilidade_rio/pontos/views.py
+++ b/mobilidade_rio/mobilidade_rio/pontos/views.py
@@ -161,9 +161,6 @@ class StopsViewSet(viewsets.ModelViewSet):
 
     def get_queryset(self):
         queryset = Stops.objects.all().order_by("stop_id")
-        stop_code = self.request.query_params.get("stop_id")
-        if stop_code is not None:
-            queryset = queryset.filter(stop_id=stop_code).order_by("stop_id")
 
         # fillter by stop_id
         stop_id = self.request.query_params.get("stop_id")

--- a/mobilidade_rio/mobilidade_rio/pontos/views.py
+++ b/mobilidade_rio/mobilidade_rio/pontos/views.py
@@ -99,7 +99,13 @@ class TripsViewSet(viewsets.ModelViewSet):
 
         if trip_id is not None:
             queryset = queryset.filter(trip_id=trip_id)
-        return queryset
+
+        # filter by route_type
+        route_type = self.request.query_params.get("route_type")
+        if route_type is not None:
+            route_type = route_type.split(",")
+            routes = Routes.objects.filter(route_type__in=route_type)
+            queryset = queryset.filter(route_id__in=routes.values_list('route_id'))
 
         # if code is not None:
         #     qrcode: QrCode = None
@@ -109,6 +115,8 @@ class TripsViewSet(viewsets.ModelViewSet):
         #         return Trip.objects.none()
         #     sequence: BaseManager = Stop_times.objects.filter(stop_id=qrcode.stop_id)
         #     queryset = queryset.filter(trip_id__in=sequence.values_list('trip_id'))
+
+        return queryset
 
 
 class ShapesViewSet(viewsets.ModelViewSet):

--- a/mobilidade_rio/mobilidade_rio/pontos/views.py
+++ b/mobilidade_rio/mobilidade_rio/pontos/views.py
@@ -197,12 +197,12 @@ class StopTimesViewSet(viewsets.ModelViewSet):
 
     def get_queryset(self):
         # get real col names and stuff
-        TRIP_ID_COL = StopTimes._meta.get_field("trip_id").column
-        STOP_ID_COL = StopTimes._meta.get_field("stop_id").column
+        TRIP_ID__STOPTIMES = StopTimes._meta.get_field("trip_id").column
+        STOP_ID__STOPTIMES = StopTimes._meta.get_field("stop_id").column
         STOPTIMES_TABLE = StopTimes._meta.db_table
 
         queryset = StopTimes.objects.all().order_by("trip_id")
-        query = f"SELECT * FROM {STOPTIMES_TABLE} ORDER BY {TRIP_ID_COL}"
+        query = f"SELECT * FROM {STOPTIMES_TABLE} ORDER BY {TRIP_ID__STOPTIMES}"
 
         # increase performance if no need to raw query
         raw_filter_used = False
@@ -215,8 +215,8 @@ class StopTimesViewSet(viewsets.ModelViewSet):
                 select="*",
                 from_target=STOPTIMES_TABLE,
                 target_is_query=False,
-                where_col_in={STOP_ID_COL: stop_id},
-                order_by=TRIP_ID_COL,
+                where_col_in={STOP_ID__STOPTIMES: stop_id},
+                order_by=TRIP_ID__STOPTIMES,
             )
             raw_filter_used = True
 
@@ -227,9 +227,9 @@ class StopTimesViewSet(viewsets.ModelViewSet):
             stop_id__all = stop_id__all.split(",")
             query = qu.q_cols_match_all(
                 table=STOPTIMES_TABLE,
-                unique_cols=[TRIP_ID_COL, STOP_ID_COL],
-                col_in={STOP_ID_COL: stop_id__all},
-                col_match_all=[TRIP_ID_COL]
+                unique_cols=[TRIP_ID__STOPTIMES, STOP_ID__STOPTIMES],
+                col_in={STOP_ID__STOPTIMES: stop_id__all},
+                col_match_all=[TRIP_ID__STOPTIMES]
             )
             raw_filter_used = True
 
@@ -242,8 +242,8 @@ class StopTimesViewSet(viewsets.ModelViewSet):
                 query = qu.q_col_in(
                     select="*",
                     from_target=query,
-                    where_col_in={TRIP_ID_COL: trip_id},
-                    order_by=TRIP_ID_COL,
+                    where_col_in={TRIP_ID__STOPTIMES: trip_id},
+                    order_by=TRIP_ID__STOPTIMES,
                 )
             else:
                 queryset = queryset.filter(trip_id__in=trip_id).order_by("trip_id")
@@ -260,16 +260,16 @@ class StopTimesViewSet(viewsets.ModelViewSet):
                 query = f"""
                 SELECT *
                 FROM ({query}) AS {qu.q_random_hash()}
-                WHERE {TRIP_ID_COL} IN (
+                WHERE {TRIP_ID__STOPTIMES} IN (
                     SELECT trip_id FROM {TRIPS_TABLE}
                     WHERE {ROUTE_ID_TRIPS} IN (
                         SELECT route_id FROM {ROUTE_TABLE}
                         WHERE route_type IN ({str(route_type)[1:-1]})
                     )
                 )
-                ORDER BY {TRIP_ID_COL}
+                ORDER BY {TRIP_ID__STOPTIMES}
                 """
-            
+
             else:
                 routes = Routes.objects.filter(route_type__in=route_type)
                 trips = Trips.objects.filter(route_id__in=routes.values_list('route_id'))

--- a/mobilidade_rio/mobilidade_rio/pontos/views.py
+++ b/mobilidade_rio/mobilidade_rio/pontos/views.py
@@ -381,55 +381,22 @@ class FrequenciesViewSet(viewsets.ModelViewSet):
     queryset = Frequencies.objects.all().order_by("trip_id")
 
     def get_queryset(self):
-        TABLE_FREQUENCIES = Frequencies._meta.db_table
-        TRIP_ID__FREQUENCIES = Frequencies._meta.get_field("trip_id").column
 
         queryset = Frequencies.objects.all().order_by("trip_id")
-        query = f"SELECT * FROM {TABLE_FREQUENCIES} ORDER BY {TRIP_ID__FREQUENCIES}"
-
-        # increase performance if no need to raw query
-        raw_filter_used = False
 
         # trip_id
         trip_id = self.request.query_params.get("trip_id")
         if trip_id is not None:
             trip_id = trip_id.split(",")
-
-            if raw_filter_used:
-                query = f"""
-                SELECT * FROM ({query}) AS {qu.q_random_hash()}
-                WHERE {TRIP_ID__FREQUENCIES} IN ({str(trip_id)[1:-1]})
-                """
-            else:
-                queryset = queryset.filter(trip_id__in=trip_id).order_by("trip_id")
+            queryset = queryset.filter(trip_id__in=trip_id).order_by("trip_id")
 
         # filter by route_type
         route_type = self.request.query_params.get("route_type")
         if route_type is not None:
             route_type = route_type.split(",")
-
-            if raw_filter_used:
-                ROUTE_TABLE = Routes._meta.db_table
-                ROUTE_ID__TRIPS = Trips._meta.get_field("route_id").column
-                TRIPS_TABLE = Trips._meta.db_table
-                query = f"""
-                SELECT *
-                FROM ({query}) AS {qu.q_random_hash()}
-                WHERE {TRIP_ID__FREQUENCIES} IN (
-                    SELECT trip_id FROM {TRIPS_TABLE}
-                    WHERE {ROUTE_ID__TRIPS} IN (
-                        SELECT route_id FROM {ROUTE_TABLE}
-                        WHERE route_type IN ({str(route_type)[1:-1]})
-                    )
-                )
-                ORDER BY {TRIP_ID__FREQUENCIES}
-                """
-            else:
-                routes = Routes.objects.filter(route_type__in=route_type)
-                trips = Trips.objects.filter(route_id__in=routes.values_list('route_id'))
-                queryset = queryset.filter(trip_id__in=trips.values_list('trip_id'))
+            routes = Routes.objects.filter(route_type__in=route_type)
+            trips = Trips.objects.filter(route_id__in=routes.values_list('route_id'))
+            queryset = queryset.filter(trip_id__in=trips.values_list('trip_id'))
 
         # execute query
-        if raw_filter_used:
-            queryset = queryset.raw(query)
         return queryset

--- a/mobilidade_rio/mobilidade_rio/pontos/views.py
+++ b/mobilidade_rio/mobilidade_rio/pontos/views.py
@@ -390,6 +390,19 @@ class FrequenciesViewSet(viewsets.ModelViewSet):
         # increase performance if no need to raw query
         raw_filter_used = False
 
+        # trip_id
+        trip_id = self.request.query_params.get("trip_id")
+        if trip_id is not None:
+            trip_id = trip_id.split(",")
+
+            if raw_filter_used:
+                query = f"""
+                SELECT * FROM ({query}) AS {qu.q_random_hash()}
+                WHERE {TRIP_ID__FREQUENCIES} IN ({str(trip_id)[1:-1]})
+                """
+            else:
+                queryset = queryset.filter(trip_id__in=trip_id).order_by("trip_id")
+
         # filter by route_type
         route_type = self.request.query_params.get("route_type")
         if route_type is not None:

--- a/mobilidade_rio/mobilidade_rio/pontos/views.py
+++ b/mobilidade_rio/mobilidade_rio/pontos/views.py
@@ -68,6 +68,21 @@ class RoutesViewSet(viewsets.ModelViewSet):
     permission_classes = (permissions.IsAuthenticatedOrReadOnly,)
     queryset = Routes.objects.all().order_by("route_id")
 
+    def get_queryset(self):
+        queryset = Routes.objects.all().order_by("route_id")
+
+        # fillter by route_id
+        route_id = self.request.query_params.get("route_id")
+        if route_id is not None:
+            queryset = queryset.filter(route_id=route_id).order_by("route_id")
+
+        # filter by route_type
+        route_type = self.request.query_params.get("route_type")
+        if route_type is not None:
+            queryset = queryset.filter(route_type=route_type).order_by("route_id")
+
+        return queryset
+
 
 class TripsViewSet(viewsets.ModelViewSet):
 

--- a/mobilidade_rio/mobilidade_rio/predictor/views.py
+++ b/mobilidade_rio/mobilidade_rio/predictor/views.py
@@ -8,6 +8,7 @@ import mobilidade_rio.pontos.models as gtfs_models
 from django.db import connection
 # import APIView
 from rest_framework.views import APIView
+import mobilidade_rio.utils.query_utils as qu
 
 
 class ShapeWithStopsView(APIView):
@@ -157,6 +158,21 @@ class ShapeWithStopsViewSet(viewsets.ModelViewSet):
 
             # execute query
             # queryset = queryset.raw(query)
+
+        # get route_type
+        route_type = None
+        if 'route_type' in self.request.query_params:
+            route_type = self.request.query_params.get('route_type')
+            route_type = route_type.split(",")
+            routes = f"""
+                SELECT route_id FROM pontos_routes
+                WHERE route_type IN ({','.join(route_type)})
+            """
+            query = f"""
+                SELECT * FROM ({query}) AS {qu.q_random_hash("q_shapes_stoptimes")}
+                WHERE route_id IN ({routes})
+            """
+
         return queryset
 
 class PredictorViewSet(viewsets.ModelViewSet):


### PR DESCRIPTION
Card criado em: https://github.com/orgs/prefeitura-rio/projects/18/views/1
Nome: [BE] Novo filtro de trips em frequencies
---
### Objetivo

Após obter a predição, as trips sem previsão serão completadas pelo horário planejado, consultando frequencies.

### Mudanças

* Novos parâmetros:
  * `trip_id` - Filtrar por 1 ou mais `trip_id`  em frequencies.

* README
  * Parâmetro `trip_id` em frequencies.

### Como usar

> Estas informações estão disponíveis no README desta atualização.

* `trip_id` - Filtra por 1 ou mais trip_id
  * Uso: `trip_id=1,2,3`
  * Exemplo real: <http://localhost:8010/gtfs/frequencies/?trip_id=O0006AAA0AVDU01,O0007AAA0AVDU01>
