### PR TITLE
Feat/stop name stops v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,24 @@ Os diagramas dos endpoints (e ) [here](https://miro.com/app/board/o9J_lqIY7Eg=/)
 
 Todos os endpoints estão no endereço `/gtfs`.
 
+#### stops
+
+Endereço: `/gtfs/stops`
+
+Parâmetros:
+
+* `stop_code` - Filtra por 1 ou mais stop_code
+  * Uso: `stop_code=1,2,3`
+  * Exemplo real: <http://localhost:8010/gtfs/stops/?stop_code=1K84,1EBQ>
+
+* `stop_name` - Filtra por 1 ou mais stop_name, não diferencia maiúsculas de minúsculas
+  * Uso: `stop_name=AB,cd,Ef`
+  * Exemplo real: <http://localhost:8010/gtfs/stops/?stop_name=term,AVen>
+
+* `stop_id` - Filtra por 1 ou mais stop_id
+  * Uso: `stop_id=1,2,3`
+  * Exemplo real: <http://localhost:8010/gtfs/stops/?stop_id=2028O00023C0,5144O00512C9>
+
 #### stop_times
 
 Endereço: `/gtfs/stop_times`

--- a/mobilidade_rio/mobilidade_rio/pontos/views.py
+++ b/mobilidade_rio/mobilidade_rio/pontos/views.py
@@ -2,6 +2,12 @@
 pontos.views - to serve API endpoints
 """
 
+# stop_code
+import operator
+from functools import reduce
+from django.db.models import Q
+from rest_framework.exceptions import ValidationError
+# etc
 from rest_framework import viewsets
 from rest_framework import permissions
 from mobilidade_rio.pontos.models import *
@@ -130,6 +136,29 @@ class StopsViewSet(viewsets.ModelViewSet):
             # split comma
             stop_code = stop_code.split(",")
             queryset = queryset.filter(stop_code__in=stop_code).order_by("stop_id")
+
+        # filter by stop_name
+        stop_name = self.request.query_params.get("stop_name")
+        if stop_name is not None:
+            stop_name = stop_name.split(",")
+
+            # if any stop_name len is < 4, return custom error message
+            for name in stop_name:
+                if len(name) < 4:
+                    raise ValidationError(
+                        {"stop_name": "stop_name must be at least 4 characters long"}
+                        )
+
+            # filter if any stop_name is substring, ignore case
+            queryset = queryset.filter(
+                reduce(
+                    operator.or_,
+                    (Q(stop_name__icontains=name) for name in stop_name)
+                    )
+                ).order_by("stop_id")
+
+            # limit final result to 10
+            # queryset = queryset[:10]
 
         return queryset
 

--- a/mobilidade_rio/mobilidade_rio/pontos/views.py
+++ b/mobilidade_rio/mobilidade_rio/pontos/views.py
@@ -118,10 +118,13 @@ class StopsViewSet(viewsets.ModelViewSet):
 
     def get_queryset(self):
         queryset = Stops.objects.all().order_by("stop_id")
-        stop_code = self.request.query_params.get("stop_id")
-        if stop_code is not None:
-            queryset = queryset.filter(stop_id=stop_code).order_by("stop_id")
 
+        # filter by stop_id
+        stop_id = self.request.query_params.get("stop_id")
+        if stop_id is not None:
+            queryset = queryset.filter(stop_id=stop_id).order_by("stop_id")
+
+        # filter by stop_code
         stop_code = self.request.query_params.get("stop_code")
         if stop_code is not None:
             # split comma


### PR DESCRIPTION
## Objetivo

Permitir que o usuário (FE) pesquise no app pelo nome da estação (stop_name), para isso precisamos filtar por stop_name o end_point stops.

No front, a atual busca é disparada quando a subtring atinge 4 caracteres.

Se for necessário, limitar a quantidade de resultados (10 resultados).

## Mudanças
* Pequeno refatoramento na view stops

* Novo parâmetro de stops: stop_name - Filtrar por 1 ou mais `stop_name`, não diferencia maiúscula e minúscula

* README
  * Adicionar informações sobre o endpoint `stops` e seus parâmetros
  * Informação sobre o novo parâmetro `stop_name`

## Como usar

> Estas informações estão disponíveis no README desta atualização.

* `stop_id` - Filtra por 1 ou mais stop_id
  * Uso: `stop_id=1,2,3`
  * Exemplo real: <http://localhost:8010/gtfs/stops/?stop_id=2028O00023C0,5144O00512C9>
