### PR TITLE
Feat/stop id parent stoptimes

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,12 @@ Parâmetros:
 
 * `stop_id` - Filtra por 1 ou mais stop_id
   * Uso: `stop_id=1,2,3`
-  * Exemplo real: <http://localhost:8010/gtfs/stop_times/?stop_id=2028O00023C0,5144O00512C9>
+  * Funcionamento:
+    * Se o stop não possuir filhos (`location_type`=0), retorna apenas ele mesmo.
+      * Exemplo real: <http://localhost:8010/gtfs/stop_times/?stop_id=2028O00023C0,5144O00512C9>
+    * Se o stop for `parent_station` de alguém (`location_type`=1), retorna apenas seus filhos.
+      * Exemplo real: <http://localhost:8010/gtfs/stop_times/?stop_id=4128O00169P0,5144O00487P9>
+    * ⚠️ Por enquanto não é possível pesquisar por `stop_id` e seus filhos ao mesmo tempo. O primeiro item deste parâmetro valerá para os demais.
 
 * `stop_id__all` - Filtra por 1 ou mais stop_id, onde as trips combinam com todos os stops passados.
   > **Por exemplo:**  

--- a/mobilidade_rio/mobilidade_rio/pontos/views.py
+++ b/mobilidade_rio/mobilidade_rio/pontos/views.py
@@ -201,11 +201,12 @@ class StopTimesViewSet(viewsets.ModelViewSet):
         stop_id__all = self.request.query_params.get("stop_id__all")
         if stop_id__all is not None:
             stop_id__all = stop_id__all.split(",")
+            # filter all trips that pass in all stops
             query = qu.q_cols_match_all(
                 table=STOPTIMES_TABLE,
                 unique_cols=[TRIP_ID_COL, STOP_ID_COL],
                 col_in={STOP_ID_COL: stop_id__all},
-                col_match_all=[TRIP_ID_COL]
+                col_match_all=[TRIP_ID_COL],
             )
             raw_filter_used = True
 

--- a/mobilidade_rio/mobilidade_rio/pontos/views.py
+++ b/mobilidade_rio/mobilidade_rio/pontos/views.py
@@ -245,12 +245,11 @@ class StopTimesViewSet(viewsets.ModelViewSet):
             trip_id = trip_id.split(",")
 
             if raw_filter_used:
-                query = qu.q_col_in(
-                    select="*",
-                    from_target=query,
-                    where_col_in={TRIP_ID_COL: trip_id},
-                    order_by=TRIP_ID_COL,
-                )
+                query = f"""
+                SELECT * FROM ({query}) AS {qu.q_random_hash()}
+                WHERE {TRIP_ID_COL} IN ({str(list(trip_id))[1:-1]})
+                ORDER BY {TRIP_ID_COL}
+                """
             else:
                 queryset = queryset.filter(
                     trip_id__in=trip_id).order_by("trip_id")

--- a/mobilidade_rio/mobilidade_rio/pontos/views.py
+++ b/mobilidade_rio/mobilidade_rio/pontos/views.py
@@ -214,17 +214,7 @@ class StopTimesViewSet(viewsets.ModelViewSet):
             # prevent error on searching inexistent stop_id
             # TODO: filter stop_id or children individually
             if len(location_type):
-                # if station has no child, return searched stations
-                if location_type[0] in (0, None):
-                    if raw_filter_used:
-                        query = f"""
-                        SELECT * FROM ({query}) AS {qu.q_random_hash()}
-                        WHERE {STOP_ID_COL} IN ({str(list(stop_id))[1:-1]})
-                        """
-                    else:
-                        queryset = queryset.filter(stop_id__in=stop_id)
-
-                # if station has no child, return searched stations
+                # if station is parent_station, return children
                 if location_type[0] == 1:
                     if raw_filter_used:
                         query = f"""
@@ -239,6 +229,16 @@ class StopTimesViewSet(viewsets.ModelViewSet):
                             stop_id__in=Stops.objects.filter(
                                 parent_station__in=stop_id).values_list("stop_id", flat=True)
                         )
+                # if station has no child, return searched stations
+                # if location_type[0] in (0, None):
+                else:
+                    if raw_filter_used:
+                        query = f"""
+                        SELECT * FROM ({query}) AS {qu.q_random_hash()}
+                        WHERE {STOP_ID_COL} IN ({str(list(stop_id))[1:-1]})
+                        """
+                    else:
+                        queryset = queryset.filter(stop_id__in=stop_id)
 
         # trip_id
         trip_id = self.request.query_params.get("trip_id")

--- a/mobilidade_rio/mobilidade_rio/pontos/views.py
+++ b/mobilidade_rio/mobilidade_rio/pontos/views.py
@@ -200,7 +200,6 @@ class StopTimesViewSet(viewsets.ModelViewSet):
         # get stop_id_all
         stop_id__all = self.request.query_params.get("stop_id__all")
         if stop_id__all is not None:
-            stop_id__all = self.request.query_params.get("stop_id__all")
             stop_id__all = stop_id__all.split(",")
             query = qu.q_cols_match_all(
                 table=STOPTIMES_TABLE,

--- a/mobilidade_rio/mobilidade_rio/pontos/views.py
+++ b/mobilidade_rio/mobilidade_rio/pontos/views.py
@@ -212,6 +212,7 @@ class StopTimesViewSet(viewsets.ModelViewSet):
                 stop_id__in=stop_id).values_list("location_type", flat=True)
 
             # prevent error on searching inexistent stop_id
+            # TODO: filter stop_id or children individually
             if len(location_type):
                 # if station has no child, return searched stations
                 if location_type[0] in (0, None):

--- a/mobilidade_rio/mobilidade_rio/pontos/views.py
+++ b/mobilidade_rio/mobilidade_rio/pontos/views.py
@@ -5,8 +5,9 @@ pontos.views - to serve API endpoints
 # stop_code
 import operator
 from functools import reduce
-from django.db.models import Q
+import django.db.models
 from rest_framework.exceptions import ValidationError
+
 # etc
 from rest_framework import viewsets
 from rest_framework import permissions
@@ -15,9 +16,13 @@ import mobilidade_rio.utils.query_utils as qu
 from .serializers import *
 from .paginations import LargePagination
 
+# import connector to query directly from database
+from django.db import connection
+
+cursor = connection.cursor()
+
 # from .utils import get_distance, safe_cast
 # from .constants import constants
-
 
 class AgencyViewSet(viewsets.ModelViewSet):
 
@@ -176,12 +181,26 @@ class StopTimesViewSet(viewsets.ModelViewSet):
         # get real col names and stuff
         TRIP_ID_COL = StopTimes._meta.get_field("trip_id").column
         STOP_ID_COL = StopTimes._meta.get_field("stop_id").column
+        PARENT_STATION__STOPS = Stops._meta.get_field("parent_station").column
 
         queryset = StopTimes.objects.all().order_by("trip_id")
         query = queryset.query
 
         # increase performance if no need to raw query
         raw_filter_used = False
+
+        # get stop_id_all
+        stop_id__all = self.request.query_params.get("stop_id__all")
+        if stop_id__all is not None:
+            stop_id__all = stop_id__all.split(",")
+            # filter all trips that pass in all stops
+            query = qu.q_cols_match_all(
+                table=queryset.query, table_is_query=True,
+                unique_cols=[TRIP_ID_COL, STOP_ID_COL],
+                col_in={STOP_ID_COL: stop_id__all},
+                col_match_all=[TRIP_ID_COL],
+            )
+            raw_filter_used = True
 
         # stop_id
         stop_id = self.request.query_params.get("stop_id")
@@ -196,27 +215,29 @@ class StopTimesViewSet(viewsets.ModelViewSet):
             if len(location_type):
                 # if station has no child, return searched stations
                 if location_type[0] in (0, None):
-                    queryset = queryset.filter(stop_id__in=stop_id)
+                    if raw_filter_used:
+                        query = f"""
+                        SELECT * FROM ({query}) AS {qu.q_random_hash()}
+                        WHERE {STOP_ID_COL} IN ({str(list(stop_id))[1:-1]})
+                        """
+                    else:
+                        queryset = queryset.filter(stop_id__in=stop_id)
 
                 # if station has no child, return searched stations
                 if location_type[0] == 1:
-                    queryset = queryset.filter(
-                        stop_id__in=Stops.objects.filter(
-                            parent_station__in=stop_id).values_list("stop_id", flat=True)
-                    )
-
-        # get stop_id_all
-        stop_id__all = self.request.query_params.get("stop_id__all")
-        if stop_id__all is not None:
-            stop_id__all = stop_id__all.split(",")
-            # filter all trips that pass in all stops
-            query = qu.q_cols_match_all(
-                table=STOPTIMES_TABLE,
-                unique_cols=[TRIP_ID_COL, STOP_ID_COL],
-                col_in={STOP_ID_COL: stop_id__all},
-                col_match_all=[TRIP_ID_COL],
-            )
-            raw_filter_used = True
+                    if raw_filter_used:
+                        query = f"""
+                        SELECT * FROM ({query}) AS {qu.q_random_hash()}
+                        WHERE {STOP_ID_COL} IN (
+                            SELECT stop_id FROM pontos_stops
+                            WHERE {PARENT_STATION__STOPS} IN ({str(list(stop_id))[1:-1]})
+                        )
+                        """
+                    else:
+                        queryset = queryset.filter(
+                            stop_id__in=Stops.objects.filter(
+                                parent_station__in=stop_id).values_list("stop_id", flat=True)
+                        )
 
         # trip_id
         trip_id = self.request.query_params.get("trip_id")
@@ -231,7 +252,8 @@ class StopTimesViewSet(viewsets.ModelViewSet):
                     order_by=TRIP_ID_COL,
                 )
             else:
-                queryset = queryset.filter(trip_id__in=trip_id).order_by("trip_id")
+                queryset = queryset.filter(
+                    trip_id__in=trip_id).order_by("trip_id")
 
         # execute query
         if raw_filter_used:

--- a/mobilidade_rio/mobilidade_rio/utils/query_utils.py
+++ b/mobilidade_rio/mobilidade_rio/utils/query_utils.py
@@ -125,6 +125,9 @@ def q_cols_match_all(
             Filter if each col has a list of values
             Recommended way to filter in this query
 
+        table_is_query (optional) : bool
+            If True, will wrap table in a subquery
+
         q_conditions (optional) : str
             Additional conditions to include in query
             TODO: filter each condition individually too
@@ -144,6 +147,10 @@ def q_cols_match_all(
 
     # validate q_conditions
     q_conditions = "\n" + " " * 12 + f"AND {q_conditions}" if q_conditions else ""
+
+    # wrap table in a subquery
+    if table_is_query:
+        table = f"({table}) as {q_random_hash()}"
 
     # filter col_match_all
     if None not in (col_match_all, col_in):


### PR DESCRIPTION
  <!--
  Kanban aberto em: https://github.com/orgs/prefeitura-rio/projects/18/views/1
  Nome: **[BE] Remover rotas noturnas em routes**
  ---
  -->
  ### Objetivo

Com a inclusão do BRT existem estações que possuem mais de uma plataforma para embarque cujo location_type é 1, quando pesquisamos o stop_id em stop_times nesse caso o retorno vazio por tratar-se de uma parent station.

Quando o location_type for 1 precisamos incluir no retorno as os dados cujo parent_station possui id igual ao id buscado.

  ### O que foi alterado?

  * Código simplificado em `stop_times`
  * Melhorias na lógica dos parâmetros em `stop_times`, ao lidar com `raw_query` quando necessário.
  * Adicionar filtro por `stop_id` ou seus filhos dependendo de seu `location_type`
  * Atualização da documentação do parâmetro `stop_id` em README
  * query_utils não necessita mais da função q_col_in().
    * **Motivo:** A função é complexa de manter e o resultado é extremamente básico.
    * **O que foi feito no lugar:** usar SQL em texto.
