### PR TITLE
Refatora código do preditor

### DIFF
--- a/mobilidade_rio/mobilidade_rio/pontos/models.py
+++ b/mobilidade_rio/mobilidade_rio/pontos/models.py
@@ -13,14 +13,14 @@ class Agency(models.Model):
     Model for agency.txt
     Mandatory fields: agency_id, agency_name, agency_url, agency_timezone
     """
+
     agency_id = models.CharField(max_length=500, blank=True, primary_key=True)
     agency_name = models.CharField(max_length=500, blank=False, null=False)
     agency_url = models.URLField(max_length=500, blank=False, null=False)
     agency_timezone = models.CharField(max_length=500, blank=False, null=False)
     agency_lang = models.CharField(max_length=500, blank=True, null=True)
     agency_phone = models.CharField(max_length=500, blank=True, null=True)
-    agency_branding_url = models.CharField(
-        max_length=500, blank=True, null=True)
+    agency_branding_url = models.CharField(max_length=500, blank=True, null=True)
     agency_fare_url = models.CharField(max_length=500, blank=True, null=True)
     agency_email = models.CharField(max_length=500, blank=True, null=True)
 
@@ -30,6 +30,7 @@ class Calendar(models.Model):
     Model for calendar.txt
     Mandatory fields: all
     """
+
     service_id = models.CharField(max_length=500, blank=True, primary_key=True)
     monday = models.IntegerField(blank=False, null=False)
     tuesday = models.IntegerField(blank=False, null=False)
@@ -39,7 +40,6 @@ class Calendar(models.Model):
     saturday = models.IntegerField(blank=False, null=False)
     sunday = models.IntegerField(blank=False, null=False)
     start_date = models.DateField(blank=False, null=False)
-    
     end_date = models.DateField(blank=False, null=False)
 
 
@@ -48,18 +48,23 @@ class CalendarDates(models.Model):
     Model for calendar_dates.txt
     Mandatory fields: service_id, date, exception_type
     """
+
     service_id = models.CharField(max_length=500, blank=False, null=False)
     date = models.DateField(blank=False, null=False)
     # TODO: change to real ENUM type in database
     exception_type = models.CharField(
-        max_length=500, blank=False, null=False,
-        choices=(('1', 'Added service'), ('2', 'Removed service')))
+        max_length=500,
+        blank=False,
+        null=False,
+        choices=(("1", "Added service"), ("2", "Removed service")),
+    )
 
     class Meta:
         """Constraints for the model"""
+
         constraints = [
             models.UniqueConstraint(
-                fields=['service_id', 'date'], name='calendar_date_id'
+                fields=["service_id", "date"], name="calendar_date_id"
             )
         ]
 
@@ -73,42 +78,56 @@ class Routes(models.Model):
     Foreign keys: agency_id
     Non GTFS fields: route_branding_url
     """
+
     route_id = models.CharField(max_length=500, blank=False, primary_key=True)
     agency_id = models.ForeignKey(
-        Agency, on_delete=models.CASCADE, blank=False, null=False)
-    route_short_name = models.CharField(
-        max_length=500, blank=False, null=False)
+        Agency, on_delete=models.CASCADE, blank=False, null=False
+    )
+    route_short_name = models.CharField(max_length=500, blank=False, null=False)
     route_long_name = models.CharField(max_length=500, blank=False, null=False)
     route_desc = models.CharField(max_length=500, blank=True, null=True)
     route_type = models.IntegerField(
-        blank=False, null=False,
-        choices=((0, 'VLT'),
-                 (1, 'Urban trains and subways'),
-                 (2, 'Interurban trains and subways'),
-                 (3, 'Bus'),
-                 (4, 'Ferry'),
-                 (5, 'Cable car'),
-                 (6, 'Gondola'),
-                 (7, 'Funicular'),
-                 (11, 'Tram'),
-                 (12, 'Monorail')))
+        blank=False,
+        null=False,
+        choices=(
+            (0, "VLT"),
+            (1, "Urban trains and subways"),
+            (2, "Interurban trains and subways"),
+            (3, "Bus"),
+            (4, "Ferry"),
+            (5, "Cable car"),
+            (6, "Gondola"),
+            (7, "Funicular"),
+            (11, "Tram"),
+            (12, "Monorail"),
+        ),
+    )
     route_url = models.URLField(max_length=500, blank=True, null=True)
     route_branding_url = models.URLField(max_length=500, blank=True, null=True)
     route_color = models.CharField(max_length=500, blank=True, null=True)
     route_text_color = models.CharField(max_length=500, blank=True, null=True)
     route_sort_order = models.PositiveIntegerField(blank=True, null=True)
     continuous_pickup = models.IntegerField(
-        blank=True, null=True,
-        choices=((0, 'embarking with continuous stops'),
-                 (1, 'no embarking available'),
-                 (2, 'set embarking with the company'),
-                 (3, 'set embarking with the driver')))
+        blank=True,
+        null=True,
+        choices=(
+            (0, "embarking with continuous stops"),
+            (1, "no embarking available"),
+            (2, "set embarking with the company"),
+            (3, "set embarking with the driver"),
+        ),
+    )
     continuous_drop_off = models.IntegerField(
-        blank=True, null=True, default=1,
-        choices=((0, 'disembarking with continuous stops'),
-                 (1, 'no disembarking available'),
-                 (2, 'set disembarking with the company'),
-                 (3, 'set disembarking with the driver')))
+        blank=True,
+        null=True,
+        default=1,
+        choices=(
+            (0, "disembarking with continuous stops"),
+            (1, "no disembarking available"),
+            (2, "set disembarking with the company"),
+            (3, "set disembarking with the driver"),
+        ),
+    )
 
 
 class Trips(models.Model):
@@ -121,32 +140,40 @@ class Trips(models.Model):
     Primary keys: trip_id, block_id
     Foreign keys: route_id, shape_id
     """
+
     route_id = models.ForeignKey(Routes, on_delete=models.CASCADE, null=True)
     service_id = models.CharField(max_length=500, blank=False, null=False)
     trip_id = models.CharField(max_length=500, blank=True, primary_key=True)
     trip_headsign = models.CharField(max_length=500, blank=True, null=True)
     trip_short_name = models.CharField(max_length=500, blank=True, null=True)
-    direction_id = models.IntegerField(blank=True, null=True,
-                                       choices=((0, 'ida'), (1, 'volta')))
+    direction_id = models.IntegerField(
+        blank=True, null=True, choices=((0, "ida"), (1, "volta"))
+    )
     block_id = models.CharField(max_length=500, blank=True, null=True)
     shape_id = models.CharField(max_length=500, blank=True, null=True)
     wheelchair_accessible = models.IntegerField(
-        blank=True, null=True,
-        choices=((0, 'information not available'),
-                 (1, 'accessible'),
-                 (2, 'not accessible')))
+        blank=True,
+        null=True,
+        choices=(
+            (0, "information not available"),
+            (1, "accessible"),
+            (2, "not accessible"),
+        ),
+    )
     bikes_allowed = models.IntegerField(
-        blank=True, null=True,
-        choices=((0, 'information not available'),
-                 (1, 'allowed'),
-                 (2, 'not allowed')))
+        blank=True,
+        null=True,
+        choices=((0, "information not available"), (1, "allowed"), (2, "not allowed")),
+    )
 
     class Meta:
         """Constraints for the model"""
+
         constraints = [
             models.UniqueConstraint(
                 # treat block_id as another primary key
-                fields=['trip_id', 'block_id'], name='trip_block_id'
+                fields=["trip_id", "block_id"],
+                name="trip_block_id",
             )
         ]
 
@@ -157,19 +184,23 @@ class Shapes(models.Model):
     Mandatory fields: shape_id, shape_pt_lat, shape_pt_lon, shape_pt_sequence
     Primary keys: shape_id + shape_pt_sequence
     """
+
     shape_id = models.CharField(max_length=500, blank=False, null=False)
     shape_pt_lat = models.FloatField(blank=False, null=False)
     shape_pt_lon = models.FloatField(blank=False, null=False)
     shape_pt_sequence = models.PositiveIntegerField(blank=False, null=False)
     shape_dist_traveled = models.FloatField(
-        blank=True, null=True, validators=[MinValueValidator(0)])
+        blank=True, null=True, validators=[MinValueValidator(0)]
+    )
 
     class Meta:
         """Constraints for the model"""
+
         constraints = [
             models.UniqueConstraint(
                 # composite primary key
-                fields=['shape_id', 'shape_pt_sequence'], name='shape_sequence_id'
+                fields=["shape_id", "shape_pt_sequence"],
+                name="shape_sequence_id",
             )
         ]
 
@@ -188,12 +219,13 @@ class Stops(models.Model):
             mandatory if location_type is 2, 3, 4
             forbidden if location_type is 1 (station, stop parent)
             optional if location_type is 0, None (platform, stop child)
-            
+
 
     Primary keys: stop_id
     Foreign keys: parent_station,
         zone_id, level_id (TODO)
     """
+
     stop_id = models.CharField(max_length=500, blank=False, primary_key=True)
     stop_code = models.CharField(max_length=500, blank=True, null=True)
     stop_name = models.CharField(max_length=500, blank=True, null=True)
@@ -203,42 +235,56 @@ class Stops(models.Model):
     zone_id = models.CharField(max_length=500, blank=True, null=True)
     stop_url = models.URLField(max_length=500, blank=True, null=True)
     location_type = models.IntegerField(
-        blank=True, null=True,
-        choices=((0, 'stop'), (1, 'station'), (2, 'entrance/exit'),
-                 (3, 'generic node'), (4, 'boarding area')))
-    parent_station = models.ForeignKey('self', on_delete=models.CASCADE, blank=True, null=True)
+        blank=True,
+        null=True,
+        choices=(
+            (0, "stop"),
+            (1, "station"),
+            (2, "entrance/exit"),
+            (3, "generic node"),
+            (4, "boarding area"),
+        ),
+    )
+    parent_station = models.ForeignKey(
+        "self", on_delete=models.CASCADE, blank=True, null=True
+    )
     stop_timezone = models.CharField(max_length=500, blank=True, null=True)
     wheelchair_boarding = models.IntegerField(
-        blank=True, null=True,
-        choices=((0, 'information not available'),
-                 (1, 'available'),
-                 (2, 'not available')))
+        blank=True,
+        null=True,
+        choices=(
+            (0, "information not available"),
+            (1, "available"),
+            (2, "not available"),
+        ),
+    )
     level_id = models.CharField(max_length=500, blank=True, null=True)
     platform_code = models.CharField(max_length=500, blank=True, null=True)
 
     class Meta:
         """Constraints for the model"""
+
         constraints = [
             # stop_lat and stop_lon are mandatory when location_type is 0, 1 or 2
             models.CheckConstraint(
                 check=~Q(location_type__in=[0, 1, 2])
                 | Q(stop_lat__isnull=False) & Q(stop_lon__isnull=False),
-                name='stop_lat_lon'
+                name="stop_lat_lon",
             ),
             models.CheckConstraint(
                 # parent_station is mandatory if location_type is 2, 3, 4
                 check=~Q(location_type__in=[2, 3, 4]) | Q(parent_station__isnull=False),
-                name='parent_station_mandatory'
+                name="parent_station_mandatory",
             ),
             # parent_station is forbidden if location_type is 1
             models.CheckConstraint(
                 check=~Q(location_type=1) | Q(parent_station__isnull=True),
-                name='parent_station_forbidden'
+                name="parent_station_forbidden",
             ),
             # treat stop_code as another primary key
             models.UniqueConstraint(
-                fields=['stop_id', 'stop_code'], name='stop_code_id'
-            )
+                fields=["stop_id", "stop_code"], name="stop_code_id"
+            ),
         ]
 
 
@@ -252,45 +298,76 @@ class StopTimes(models.Model):
     Primary keys: trip_id + stop_sequence + stop_id
     Foreign keys: trip_id, stop_id
     """
-    trip_id = models.ForeignKey(Trips, on_delete=models.CASCADE,
-                                related_name='trip_id_id', related_query_name='trip_id_id')
+
+    trip_id = models.ForeignKey(
+        Trips,
+        on_delete=models.CASCADE,
+        related_name="trip_id_id",
+        related_query_name="trip_id_id",
+    )
     stop_sequence = models.PositiveIntegerField(blank=False, null=False)
-    stop_id = models.ForeignKey(Stops, on_delete=models.CASCADE,
-                                related_name='stop_id_id', related_query_name='stop_id_id')
+    stop_id = models.ForeignKey(
+        Stops,
+        on_delete=models.CASCADE,
+        related_name="stop_id_id",
+        related_query_name="stop_id_id",
+    )
     arrival_time = models.CharField(blank=True, null=True, max_length=10)
     departure_time = models.CharField(blank=True, null=True, max_length=10)
     stop_headsign = models.CharField(max_length=500, blank=True, null=True)
     pickup_type = models.IntegerField(
-        blank=True, null=True, default=1,
-        choices=((0, 'regularly scheduled embarking'),
-                 (1, 'no embarking available'),
-                 (2, 'set embarking with the company'),
-                 (3, 'set embarking with the driver')))
+        blank=True,
+        null=True,
+        default=1,
+        choices=(
+            (0, "regularly scheduled embarking"),
+            (1, "no embarking available"),
+            (2, "set embarking with the company"),
+            (3, "set embarking with the driver"),
+        ),
+    )
     drop_off_type = models.IntegerField(
-        blank=True, null=True, default=1,
-        choices=((0, 'regularly scheduled disembarking'),
-                 (1, 'no disembarking available'),
-                 (2, 'set disembarking with the company'),
-                 (3, 'set disembarking with the driver')))
+        blank=True,
+        null=True,
+        default=1,
+        choices=(
+            (0, "regularly scheduled disembarking"),
+            (1, "no disembarking available"),
+            (2, "set disembarking with the company"),
+            (3, "set disembarking with the driver"),
+        ),
+    )
     continuous_pickup = models.IntegerField(
-        blank=True, null=True,
-        choices=((0, 'embarking with continuous stops'),
-                 (1, 'no embarking available'),
-                 (2, 'set embarking with the company'),
-                 (3, 'set embarking with the driver')))
+        blank=True,
+        null=True,
+        choices=(
+            (0, "embarking with continuous stops"),
+            (1, "no embarking available"),
+            (2, "set embarking with the company"),
+            (3, "set embarking with the driver"),
+        ),
+    )
     continuous_drop_off = models.IntegerField(
-        blank=True, null=True, default=1,
-        choices=((0, 'disembarking with continuous stops'),
-                 (1, 'no disembarking available'),
-                 (2, 'set disembarking with the company'),
-                 (3, 'set disembarking with the driver')))
+        blank=True,
+        null=True,
+        default=1,
+        choices=(
+            (0, "disembarking with continuous stops"),
+            (1, "no disembarking available"),
+            (2, "set disembarking with the company"),
+            (3, "set disembarking with the driver"),
+        ),
+    )
     shape_dist_traveled = models.FloatField(
-        max_length=500, blank=True, null=True, validators=[MinValueValidator(0)])
-    timepoint = models.IntegerField(blank=True, null=True,
-                                    choices=((0, 'exact time'), (1, 'approximate time')))
+        max_length=500, blank=True, null=True, validators=[MinValueValidator(0)]
+    )
+    timepoint = models.IntegerField(
+        blank=True, null=True, choices=((0, "exact time"), (1, "approximate time"))
+    )
 
     class Meta:
         """Constraints for the model"""
+
         # composite primary key: trip_id + stop_sequence + stop_id
         constraints = [
             # TODO: For testing purposes, this composite primary key is disabled
@@ -309,27 +386,34 @@ class Frequencies(models.Model):
     Primary keys: trip_id + start_time
     Foreign keys: trip_id
     """
-    trip_id = models.ForeignKey(Trips, on_delete=models.CASCADE, blank=False, null=False)
+
+    trip_id = models.ForeignKey(
+        Trips, on_delete=models.CASCADE, blank=False, null=False
+    )
     # ? `start_time` and `end_time` can exceed 23:59:59, so they are stored as Char
     start_time = models.CharField(blank=False, null=False, max_length=10)
     end_time = models.CharField(blank=False, null=False, max_length=10)
     headway_secs = models.PositiveIntegerField(blank=False, null=False)
-    exact_times = models.IntegerField(blank=True, null=True,
-                                      choices=((0, 'frequency-based trips'), (1, 'exact times')))
+    exact_times = models.IntegerField(
+        blank=True,
+        null=True,
+        choices=((0, "frequency-based trips"), (1, "exact times")),
+    )
 
     class Meta:
         """Constraints for the model"""
+
         constraints = [
             models.UniqueConstraint(
-                fields=['trip_id', 'start_time'], name='frequency_id'
+                fields=["trip_id", "start_time"], name="frequency_id"
             ),
             # if start_time and end_time are hh:mm:ss
             models.CheckConstraint(
-                check=Q(start_time__regex=r'^[0-9]+:[0-9]{1,2}:[0-9]{1,2}$'),
-                name='start_time_format',
+                check=Q(start_time__regex=r"^[0-9]+:[0-9]{1,2}:[0-9]{1,2}$"),
+                name="start_time_format",
             ),
             models.CheckConstraint(
-                check=Q(end_time__regex=r'^[0-9]+:[0-9]{1,2}:[0-9]{1,2}$'),
-                name='end_time_format'
+                check=Q(end_time__regex=r"^[0-9]+:[0-9]{1,2}:[0-9]{1,2}$"),
+                name="end_time_format",
             ),
         ]

--- a/mobilidade_rio/mobilidade_rio/predictor/utils.py
+++ b/mobilidade_rio/mobilidade_rio/predictor/utils.py
@@ -1,16 +1,17 @@
 """Utils for predictor app"""
 import os
-import json
 from datetime import datetime, timedelta
 from pyproj import Transformer
 import requests
-from shapely import LineString, Point
+from shapely.geometry import LineString, Point
 from shapely.ops import snap, split, transform
 from django.utils import timezone
 import pandas as pd
-from mobilidade_rio.pontos.models import *
+from mobilidade_rio.pontos.models import Stops, Trips, Calendar, CalendarDates, Shapes
 
-class Predictor():
+
+class Predictor:  # pylint: disable=C0301
+    # TODO: change to google style: https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings # pylint: disable=W0511
     """
     Input:
         stop_code           1st option, easy for frontend to implement
@@ -21,193 +22,149 @@ class Predictor():
     Output:
         Dataframe with realtime API fields + ETA (Estimated Time of Arrival)
     """
-    def __init__(self,
-        stop_code:list=None, direction_id:list=None, trip_short_name:list=None,
-        debug_cols:bool=False
-        ):
 
-        self.map_weekday_servie_id = {0: "U", 1: "U", 2: "U", 3: "U", 4: "U", 5: "S", 6: "D"}
-        self.map_stops = pd.DataFrame()
-        self.df_realtime = pd.DataFrame()
+    def __init__(
+        self,
+        stop_id: int,
+        direction_id: list = None,
+        trip_short_name: list = None,
+        service_id: str = None,
+    ):
 
-        self._get_df_realtime()
-
-        # init 1 - insert at least stop_code
-        self.stop_code = stop_code
+        self.stop_id = stop_id
         self.trip_short_name = trip_short_name
         self.direction_id = direction_id
-        self.debug_cols = debug_cols
+        self.service_id = self._get_service_id() if service_id is None else service_id
+        self.stop_pt = self._get_stop_pt()
 
-        # init 2 - no 3 params, add if not exists
-        self._get_inputs()
+        # set inputs to run iteration
+        self.inputs = self._set_inputs()
 
-        # set useful parameters
-        # TODO: definir qual o service_id do momento da chamada (BACKLOG)
-        self._get_service_id()
-        self._get_shape_id() # OK: trocar p acesso via modelo do django
         # default CRS transformer
         self.crs = Transformer.from_crs("epsg:4326", "epsg:31983")
 
+    def _get_stop_pt(self):
+        """
+        Get stop point from stop_id.
+        """
+        stop = Stops.objects.get(stop_id=self.stop_id)
+        return Point(stop.stop_lon, stop.stop_lat)
 
-    def _get_df_realtime(self, ignore_old_data=True) -> bool:
-        # Fetch realtime api
-        # TODO: can be good to set as env only
-        url = os.environ.get('API_REALTIME', "https://dados.mobilidade.rio/gps/brt")
-        print("URL ENV:", url)
-        if not url:
-            print("[_get_df_realtime error]: Envs not found")
-            return False
-        # headers = json.loads(headers)
-        api_response = requests.get(url,timeout=10)
-        json_api_response = json.loads(api_response.text)
-        if api_response.status_code != 200:
-            print("[_get_df_realtime error]: Request to API realtime got error:")
-            print(json_api_response)
-            return
+    def _set_inputs(self):
+        """
+        For each direction_id and trip_short_name, get the shape_id
+        and set the inuts for the model.
+        """
+        inputs = []
+        for direction_id in self.direction_id:
+            for trip_short_name in self.trip_short_name:
+                shape_id = self._get_shape_id(
+                    trip_short_name, direction_id, self.service_id
+                )
+                inputs.append(
+                    {
+                        "stop_id": self.stop_id,
+                        "direction_id": direction_id,
+                        "trip_short_name": trip_short_name,
+                        "service_id": self.service_id,
+                        "shape_id": shape_id,
+                    }
+                )
 
-        df_realtime = pd.DataFrame(pd.json_normalize(json_api_response['veiculos']))
+        return inputs
 
-        # TODO: mudar nomes das colunas q forem do gtfs (linha -> trip_short_name, ...)
-        df_realtime.rename(columns={"linha": "trip_short_name"}, inplace=True)
-        df_realtime["direction_id"] = df_realtime["sentido"].apply(lambda x: 1 if x == 'volta' else 0)
+    def _get_realtime(self, max_delay_secs=120):
 
-        # trip_headsign
-        trip_short_name = list(df_realtime['trip_short_name'].unique())
-        trips = Trips.objects.filter(trip_short_name__in=trip_short_name
-            ).distinct("trip_short_name","direction_id")
-        df_map = pd.DataFrame(trips.values("trip_short_name","direction_id","trip_headsign"))
-        df_realtime = pd.merge(df_realtime, df_map, on=["trip_short_name","direction_id"], how='left')
+        # TODO: change to internal API, get secrets from Vault # pylint: disable=W0511
+        url = os.environ.get("API_REALTIME", "https://dados.mobilidade.rio/gps/brt")
+        response = requests.get(url, timeout=5)
 
+        if not response.ok:
+            raise Exception(f"API error: {response.status_code} - {response.reason}")
 
-        # OK: converter unixtime -> datetime
-        df_realtime["dataHora"] = (df_realtime["dataHora"] / 1000).apply(datetime.fromtimestamp)
-        # weekday
-        # TODO @yxuo: Confirmar se o map {5:"S",6:"D"} está correto.
-        df_realtime["service_id"] = df_realtime["dataHora"].dt.weekday.map(self.map_weekday_servie_id)
+        data = pd.DataFrame(pd.json_normalize(response.json()["veiculos"]))
 
-        # Ignore vehicles older than 20s
-        if ignore_old_data:
-            df_realtime = df_realtime[df_realtime["dataHora"]
-                                    > (datetime.now() - timedelta(seconds=20))]
-            if df_realtime.empty:
-                print("[_get_df_realtime error] no vehicles in the last 20s.")
-                return False
+        # rename columns
+        data.rename(columns={"linha": "trip_short_name"}, inplace=True)
+        data["direction_id"] = data["sentido"].apply(lambda x: 1 if x == "volta" else 0)
 
-        self.df_realtime = df_realtime
-        return True
+        # conver unix to datetime
+        data["dataHora"] = (data["dataHora"] / 1000).apply(datetime.fromtimestamp)
 
+        data = data[
+            data["dataHora"] > (datetime.now() - timedelta(seconds=max_delay_secs))
+        ]
 
-    def _get_inputs(self):
-        if self.df_realtime.empty:
-            if self.df_realtime.empty:
-                print("[_get_inputs error]: API realtime got no results")
-                return
+        if data.empty:
+            raise Exception("API error: no results")
 
-        # Get valid trips (api vs database)
-        df_api = self.df_realtime.copy()
-        df_api = df_api.drop_duplicates(subset=["trip_short_name","direction_id"])
-        unique_trips = Trips.objects.all().distinct("trip_short_name", "direction_id")
-        df_trips = pd.DataFrame(unique_trips.values("trip_short_name", "direction_id","trip_id"))
-        # Create A
-        df_valid = pd.merge(df_api, df_trips, on=["trip_short_name","direction_id"], how='left')
-        # Create B
-        children = StopTimes.objects.all().exclude(  # valid_stoptimes_child
-            stop_id__parent_station__stop_code=None)
-        if not children.exists():
-            print("ERROR: stoptimes has no stop child - stoptimes total len:",len(children))
-            return
-
-        # Filter trips with inputs - 1,2,3 filter A
-        # TODO: filter combination of {trip_short_name: [direction_id]}
-        if self.trip_short_name:
-            df_valid = df_valid[df_valid["trip_short_name"].isin(self.trip_short_name)]
-        if self.direction_id:
-            df_valid = df_valid[df_valid["direction_id"].isin(self.direction_id)]
-        if self.stop_code:
-            # filter children by stop_code and get trips
-            list_children_trips = list(children.filter(
-                stop_id__parent_station__stop_code__in=self.stop_code).distinct("trip_id"
-                ).values_list("trip_id", flat=True))
-            df_valid = df_valid[df_valid["trip_id"].isin(list_children_trips)]
-            
-        # Set inputs - A updates 1,2
-        if not self.trip_short_name:
-            self.trip_short_name = list(df_valid["trip_short_name"].unique())
-        if not self.direction_id:
-            self.direction_id = list(df_valid['direction_id'].unique())
-
-        # A (1,2,3) updates B
-        children = children.filter(
-            trip_id__trip_short_name__in=df_valid["trip_short_name"].to_list(),
-            trip_id__direction_id__in=df_valid["direction_id"].to_list(),
-            )
-        if not self.stop_code:
-            # B updates 3
-            self.stop_code = list(children.distinct("stop_id__parent_station__stop_code"
-                ).values_list("stop_id__parent_station__stop_code",flat=True))
-
-        # Get map of stops
-        map_stops = pd.DataFrame(children.values(
-            "stop_id",  # debug
-            "trip_id",  # debug
-            "stop_id__parent_station__stop_code",
-            "trip_id__trip_short_name",
-            "trip_id__direction_id",
-            "trip_id__shape_id",
-            ))
-        map_stops.columns = map_stops.columns.str.replace(r'^.*__', '', regex=True)
-        self.map_stops = map_stops
-
+        return data
 
     def _get_service_id(self):
-        # 1. Filtrar data do calendar_dates vs calendar (excessão vs regra)
+
         today_date = timezone.now().date()
-        services = CalendarDates.objects.filter(date=today_date)
-        if not services.exists():
-            services = Calendar.objects.filter(start_date__lte=today_date, end_date__gte=today_date)
-        # 2. Filtrar dia da semana
-        weekday = today_date.strftime(f"%A").lower()
-        services = services.filter(**{weekday: 1})
-        if not services.exists():
-            print("[_get_service_id error] calendar and calendar_dates got no results - "
-            f"weekday now: {weekday}")
-            return
-        self.service_id = list(services.values_list("service_id", flat=True))
 
+        # Check for date exceptions
+        services = CalendarDates.objects.filter(date=today_date).filter(
+            exception_type=1
+        )
 
-    # move to _get_input
-    def _get_shape_id(self):
-        # get the first trip matched, could be more - TODO: add rule to FE get the same trip_id (BACKLOG)
+        if len(services) > 1:
+            raise Exception(
+                "Multiple services found for today. Please set a specific service_id."
+            )
+        if len(services) == 1:
+            return services.values_list("service_id", flat=True)[0]
+
+        # Check for regular service
+        weekday = today_date.strftime("%A").lower()
+        services = Calendar.objects.filter(
+            start_date__lte=today_date, end_date__gte=today_date
+        ).filter(**{weekday: 1})
+
+        if len(services) > 1:
+            return Exception(
+                "Multiple services found for today. Please set a specific service_id."
+            )
+        if len(services) == 0:
+            raise Exception("No service found for today.")
+
+        return services.values_list("service_id", flat=True)[0]
+
+    def _get_shape_id(self, trip_short_name, direction_id, service_id):
+        # get the first trip matched, could be more - TODO: add rule to
+        # FE get the same trip_id (BACKLOG) # pylint: disable=W0511
         # shape_id = queryset_to_list(trips, ['shape_id'])
 
         trips = Trips.objects.filter(
-            trip_short_name__in=self.trip_short_name,
-            direction_id__in=self.direction_id,
-            service_id__in=self.service_id,
+            trip_short_name__in=trip_short_name,
+            direction_id__in=direction_id,
+            service_id__in=service_id,
         )
-        if not trips.exists():
-            print(
-                "[get_shape_id error] trips query is empty - "
-                f"trip_short_name: {self.trip_short_name} "
-                f"direction_id: {self.direction_id} "
-                f"service_id: {self.service_id}.",
-                "Result: Query for Shapes won't be created without this query"
+
+        if len(trips) == 0:
+            raise Exception("No trips found for the given inputs.")
+
+        shapes = trips.distinct("shape_id")
+
+        if len(shapes) > 1:
+            raise Exception(
+                "Multiple shapes found for the given inputs. Please set specfic a shape_id."
             )
-            self.shape_id = None
-            return
+        if (
+            len(shapes) == 0
+        ):  # works if shape_id is null? TODO: check for this chatch # pylint: disable=W0511
+            raise Exception("No shapes found for the given inputs.")
 
-        self.shape_id = list(trips.distinct("shape_id").values_list("shape_id", flat=True))
+        return shapes.values_list("shape_id", flat=True)[0]
 
-
-    def split_shape(self, pt, part=0):
+    def _split_shape(self, shape, break_pt, part=0):
         """
         Splits a shape based on a point. By default gets only the first part.
         """
-        # print(split(snap(self.shape, pt, 1e-8), pt).geoms[part])
-        return split(snap(self.shape, pt, 1e-8), pt).geoms[part]
+        return split(snap(shape, break_pt, 1e-8), break_pt).geoms[part]
 
-
-    def get_shape_lenght(self, shape, unit="km"):
+    def _get_shape_lenght(self, shape, unit="km"):
         """
         Calculates the shape lenght over the choosen CRS. To change the CRS, check the attribute self.crs.
         """
@@ -217,141 +174,99 @@ class Predictor():
             return lenght / 1000
         return lenght
 
-
-    def get_eta(self):
-        # Requirements
-        if not self.trip_short_name:
-            print(f"[get_eta error]: invalid trip_short_name: '{self.trip_short_name}'")
-            return None
-        if not self.shape_id:
-            print(f"[get_eta error]: invalid shape_id: '{self.shape_id}'")
-            return None
-        
-        # If filter inputs got no results
-        if self.map_stops.empty:
-            return None
-
-        # Concat results for each shape (trip_short_name)
-        rt = self.df_realtime
-        ret = pd.DataFrame(columns=rt.columns)
-        for shape_id in self.shape_id:
-
-            # shape position
-            shape = Shapes.objects.filter(shape_id=shape_id)
-            df = self.map_stops.copy()
-            # ? Each map_stops is a stoptime row with extra fields, so normally direction_id has 1 value
-            # ? You can filter stoptimes by shape_id, trip_short_name, direction_id
-            #   to check result
-            df_shape = df.loc[df["shape_id"]==shape_id]
-            trip_short_name = list(df_shape["trip_short_name"].unique())
-            direction_id = list(df_shape["direction_id"].unique())
-
-            # stop pt per stop_code (parent) to simplify
-            # TODO: to increase precision, for each shape filter by stop child pos
-            # ? For now it only filter bt 1 stop_code
-            stops = Stops.objects.filter(stop_code=self.stop_code[0])
-            stop_pt = Point(stops[0].stop_lat, stops[0].stop_lon)
-
-            # TODO: solve error - invalid value encountered in line_locate_point
-            self.shape = LineString([(s.shape_pt_lat, s.shape_pt_lon) for s in shape])#.wkt
-
-            # Get vehicle positions in this shape
-            positions = rt.copy()
-            # TODO: filter combination of {trip_short_name: [direction_id]}
-            positions = positions[(
-                positions.trip_short_name.isin(trip_short_name)) 
-                & (positions.direction_id.isin(direction_id))
-            ].copy()
-
-            if positions.empty:
-                print("[get_eta warning]: "
-                    f"trip_short_name={trip_short_name} and direction_id={direction_id} "
-                    "not found in API realtime (positions)",
-                    f"realtime results: {len(rt.loc[rt['trip_short_name'].isin(trip_short_name)])}"
-                    )
-                continue
-
-            # get vehicle positions and project them into the shape
-            positions["px"] = positions.apply(lambda x: Point(x.latitude, x.longitude), axis=1)
-            # TODO: solve error - invalid value encountered in line_locate_point (interpolate?, projecet?)
-            positions["px_proj"] = positions.apply(lambda x: self.shape.interpolate(self.shape.project(x.px)), axis=1)
-
-            # calculate distance from shape_start_pt to vehicle
-            positions["d_shape"] = positions.px_proj.apply(lambda x: self.get_shape_lenght(self.shape))
-            positions["d_start_to_px"] = positions.px_proj.apply(
-                lambda x: self.get_shape_lenght(self.split_shape(x)))
-
-            # calculate distance from vehicle to stop
-            # TODO: solve error - invalid value encountered in line_locate_point (interpolate?, projecet?)
-            stop_pt_proj = self.shape.interpolate(self.shape.project(stop_pt))
-            d_start_to_stop = self.get_shape_lenght(self.split_shape(stop_pt_proj))
-
-            positions["d_start_to_stop"] = d_start_to_stop
-            positions["d_px_to_stop"] = d_start_to_stop - positions.d_start_to_px
-            positions["estimated_time_arrival"] = positions.apply(lambda x: 60 * x.d_px_to_stop / float(
-                x.velocidade) if float(x.velocidade) > 0 else x.d_px_to_stop, axis=1)
-
-            positions = positions[positions.estimated_time_arrival >= 0]
-            positions = positions.sort_values("estimated_time_arrival")
-            positions["shape_id"] = shape_id
-            positions["stop_code"] = self.stop_code[0]
-            positions["shape_id"] = shape_id
-
-            if ret.empty:
-                ret = positions.copy()
-            else:
-                ret = pd.concat([ret, positions]).copy()
-        print("len ret FINAL:", len(ret))
-
-        # TODO: mudar nomes das colunas q forem do gtfs (linha -> trip_short_name, ...)
-        ret_cols = [
-            # API fields
-            "codigo",                   # pk
-            "dataHora",                 # created at
-            "latitude",                 # current vehicle lat
-            "longitude",                # current vehicle lon
-            # trajeto: 22 - J. OCEÂNICO X ALVORADA (PARADOR) [VOLTA]
-            # trajeto: <trip_short_name> - <API.route_long_name> [<sentido.uppercase()>]
-            "trajeto",                  # API name of trip
-            "velocidade",
-            
-            # GTFS fields
-            "trip_short_name",          # linha
-            "direction_id",             # sentido = ida,volta vs direction_id = 0,1
-            "trip_headsign",
-
-            # Frontend fields
-            "estimated_time_arrival",   # in minutes?
-        ]
-        if self.debug_cols:
-            ret_cols += [
-                # Debug fields
-                "shape_id",                 # classified by shape_id
-                "stop_code",                # It uses the first stop_code
-            ]
-        return ret[ret_cols].to_dict(orient="records")
-
-
-    def __repr__(self) -> str:
-        str_map_stops = "Empty"
-        if not self.map_stops.empty:
-            str_map_stops = f"""
-            unique stop_code: {len(self.map_stops["stop_code"].unique())}
-            unique trip_short_name: ({len(self.map_stops["trip_short_name"].unique())})
-            unique direction_id: {len(self.map_stops["direction_id"].unique())}
-            unique shape_id: {len(self.map_stops["shape_id"].unique())}
-            """
-
-        return f"""\
-Predictor values:
-    input:
-        stop_code: ({len(self.stop_code)}) {self.stop_code}
-        trip_short_name: ({len(self.trip_short_name)}) {self.trip_short_name}
-        direction_id: ({len(self.direction_id)}) {self.direction_id}
-    processing:
-        service_id: '{self.service_id}'
-        shape_id: ({len(self.shape_id)}) {self.shape_id}
-        map_stops: ({len(self.map_stops)}) {str_map_stops}
-        df_realtime: ({len(self.df_realtime)})
-        \
+    def get_trip_eta(self, direction_id, trip_short_name, shape_id):
         """
+        Gets ETA of all vehicle to a stop, operating on a specific trip.
+        """
+
+        # get vehicle positions
+        positions = self._get_realtime()
+        positions = positions[
+            (positions.trip_short_name == trip_short_name)
+            & (positions.direction_id == direction_id)
+        ].copy()
+
+        # get shape
+        shape = Shapes.objects.filter(shape_id=shape_id)
+        shape = LineString(list(zip(shape.shape_pt_lat, shape.shape_pt_lon)))  # .wkt
+
+        # project vehicle positions into the shape
+        positions["px"] = positions.apply(
+            lambda x: Point(x.latitude, x.longitude), axis=1
+        )
+        positions["px_proj"] = positions.apply(
+            lambda x: shape.interpolate(shape.project(x.px)), axis=1
+        )
+
+        # calculate distance from shape_start_pt to vehicle
+        positions["d_shape"] = positions.px_proj.apply(
+            lambda x: self._get_shape_lenght(shape)
+        )
+        positions["d_start_to_px"] = positions.px_proj.apply(
+            lambda x: self._get_shape_lenght(self._split_shape(shape, x))
+        )
+
+        # calculate distance from shape_start_pt to stop
+        stop_pt_proj = shape.interpolate(shape.project(self.stop_pt))
+        positions["d_start_to_stop"] = self._get_shape_lenght(
+            self._split_shape(shape, stop_pt_proj)
+        )
+
+        # calculate distance from vehicle to stop (diff from above ones)
+        positions["d_px_to_stop"] = positions.d_start_to_stop - positions.d_start_to_px
+
+        # convert to eta
+        positions["estimated_time_arrival"] = positions.apply(
+            lambda x: 60 * x.d_px_to_stop / float(x.velocidade)
+            if float(x.velocidade) > 0
+            else x.d_px_to_stop,
+            axis=1,
+        )
+
+        positions = positions[positions.estimated_time_arrival >= 0].sort_values(
+            "estimated_time_arrival"
+        )
+
+        cols = [
+            "codigo",  # pk
+            "dataHora",  # created at
+            "latitude",  # current vehicle lat
+            "longitude",  # current vehicle lon
+            "velocidade",
+            "trip_short_name",  # linha
+            "direction_id",  # 0, 1
+            "estimated_time_arrival",  # in minutes
+        ]
+
+        return positions[cols].to_dict(orient="records")
+
+    def run_eta(self):
+        """
+        Runs ETA of all vehicle to a single stop.
+        """
+        for params in self._set_inputs():
+            self.get_trip_eta(**params)
+
+
+# TODO: precisa manter esse __repr__? # pylint: disable=W0511
+#     def __repr__(self) -> str:
+#         str_map_stops = "Empty"
+#         if not self.map_stops.empty:
+#             str_map_stops = f"""
+#             unique stop_code: {len(self.map_stops["stop_code"].unique())}
+#             unique trip_short_name: ({len(self.map_stops["trip_short_name"].unique())})
+#             unique direction_id: {len(self.map_stops["direction_id"].unique())}
+#             unique shape_id: {len(self.map_stops["shape_id"].unique())}
+#             """
+
+#         return f"""\
+# Predictor values:
+#     input:
+#         stop_code: ({len(self.stop_code)}) {self.stop_code}
+#         trip_short_name: ({len(self.trip_short_name)}) {self.trip_short_name}
+#         direction_id: ({len(self.direction_id)}) {self.direction_id}
+#     processing:
+#         service_id: '{self.service_id}'
+#         shape_id: ({len(shape_id)}) {shape_id}
+#         \
+#         """

--- a/mobilidade_rio/mobilidade_rio/settings/base.py
+++ b/mobilidade_rio/mobilidade_rio/settings/base.py
@@ -140,7 +140,7 @@ DJOSER = {
 
 LANGUAGE_CODE = 'en-us'
 
-TIME_ZONE = 'UTC'
+TIME_ZONE = 'America/Sao_Paulo'
 
 USE_I18N = True
 


### PR DESCRIPTION
*Para ler e analisar o código com calma!*

O modelo em si não muda, apenas algumas correções foram feitas no código.

Resumo das mudanças e correções por arquivo:

`mobilidade_rio/mobilidade_rio/settings/base.py`:
- Corrige timezone para GMT-3. A hora do GPS estava sendo convertida 3 horas para frente.

`mobilidade_rio/mobilidade_rio/predictor/utils.py`: (🌊)
- Corrige imports do `shapely` e remove imports genéricos (pylint wildcard-import [W0401](https://pylint.readthedocs.io/en/latest/user_guide/checkers/features.html))
- Altera parâmetros de entrada:
  - Uso do stop_id (filho) ao invés do stop_code (pai), para simplificar o código
  - Remove `map_weekday_servie_id`: não é necessário esse mapeamento, o service_id correto é obtido via calendar + calendar_dates
- Remove `get_inputs`: essa função ficou super complexa! foi muito mais simples trocar o stop_code para stop_id como entrada e não precisar decidir quanto aos stops filhos, trips, etc, no código.
- Correções e melhorias em `_get_service_id`, `_get_shape_id`
- Separa chamadas do modelo em:
  - `get_trip_eta`: ETA para uma trip especifica de um ponto
  - `run_eta`: ETA para todas as trips de um ponto (wrapper, apenas itera nos parâmetros retornados por `_set_inputs` e chama `get_trip_eta` para cada conjunto de parâmetros)

`mobilidade_rio/mobilidade_rio/pontos/models.py`:
- Apenas ajusta formatação com [black](https://dev.to/adamlombard/how-to-use-the-black-python-code-formatter-in-vscode-3lo0)

*Para checar com atenção:*

- Prints substituídos por `raises`- comportamentos como a API vazia devem ser reportados como erro, e o FE passa a lidar com esses erros. Os raises estão corretos?
- Colunas de debug foram removidas - são necessárias?
- Funcao `__repr__` removida - é necessária?